### PR TITLE
do not fail if there is no role attached

### DIFF
--- a/chef_inventory.py
+++ b/chef_inventory.py
@@ -133,11 +133,12 @@ class ChefInventory:
                 groups[environment] = []
             groups[environment].append(name)
 
-            for r in node["automatic"]["roles"]:
-                role = self.to_safe(r)
-                if role not in groups:
-                    groups[role] = []
-                groups[role].append(name)
+            if node["automatic"]["roles"] is not None:
+                for r in node["automatic"]["roles"]:
+                    role = self.to_safe(r)
+                    if role not in groups:
+                        groups[role] = []
+                    groups[role].append(name)
 
             for i in node["run_list"]:
                 m = re.match(r'(role|recipe)\[(.*)\]', i)


### PR DESCRIPTION
Without this check --list operation fails as this: 

```
Traceback (most recent call last):
  File "./chef_inventory.py", line 178, in <module>
    main()
  File "./chef_inventory.py", line 174, in main
    ci.execute()
  File "./chef_inventory.py", line 165, in execute
    self.list_nodes()
  File "./chef_inventory.py", line 136, in list_nodes
    for r in node["automatic"]["roles"]:
TypeError: 'NoneType' object is not iterable
```
